### PR TITLE
#164326073 Fix password rematch validation.

### DIFF
--- a/api/auth/serializers.py
+++ b/api/auth/serializers.py
@@ -109,6 +109,7 @@ class UidAndTokenSerializer(serializers.Serializer):
 
         return attrs
 
+
 class LoginTokenSerializer(serializers.Serializer):
     """
     This serializer serializes the token data
@@ -116,6 +117,7 @@ class LoginTokenSerializer(serializers.Serializer):
     token = serializers.CharField(max_length=255)
     username = serializers.CharField()
     password = serializers.CharField(style={'input_type': 'password'})
+
 
 class UidAndTokenQueryParamsSerializer(serializers.Serializer):
 


### PR DESCRIPTION
#### What does this PR do?
Validate password rematch during resetting password and refactor tests.
#### Description of Task to be completed?
Validate password rematch at `/api/auth/reset_password_confirm/` url and refactor tests for the endpoint.
#### How should this be manually tested?
1. Clone this repo.
   `git clone https://github.com/jkamz/ireporter.git`
2. Fetch all origin to get all branches
   `git fetch origin`
3. Checkout to `ft-reset-password-email-164326073` branch.
   `git checkout ft-reset-password-email-164326073`
4. Activate `virtualenv`
    `$ virtualenv -p python .venv`
    `$ source .venv/bin/activate`
5. Install requirements
   `$ pip install -r requirements.txt`
6. Start server
   `$ python api/manage.py runserver`
7. Test the endpoint on postman in the following steps:
      - `POST /api/auth/signup/`
      - `POST /api/auth/activate/`
      - `POST /api/auth/reset_password/`
      -  `PATCH /api/auth/reset_password_confirm/?uid=string_uid&token=generated_token`
      - Enter passwords that don't match to test the endpoint.
8. Run tests:
   `$ python api/manage.py test`
#### What are the relevant pivotal tracker stories?
[#164326073](https://www.pivotaltracker.com/story/show/164326073)
#### Screenshot
![image](https://user-images.githubusercontent.com/17095461/54426737-9fb23b80-4729-11e9-8451-e14bf723ca73.png)
![image](https://user-images.githubusercontent.com/17095461/54426526-26b2e400-4729-11e9-8d1a-175f9cc5e895.png)
![image](https://user-images.githubusercontent.com/17095461/54426581-48ac6680-4729-11e9-9fea-87be20d4a2e3.png)



