### PR TITLE
#164691118 Fix deletion of red-flag record if processed

### DIFF
--- a/api/incidents/views.py
+++ b/api/incidents/views.py
@@ -66,7 +66,12 @@ class RedflagView(viewsets.ModelViewSet):
         try:
             instance = self.get_object()
 
-            if int(instance.createdBy) != user_id:
+            if not 'draft' in instance.status.lower():
+
+                response['status'], response['error'] = 403, 'This record is {}. You can not delete it.'.format(
+                    instance.status.lower())
+
+            elif int(instance.createdBy) != user_id:
 
                 response['status'], response['error'] = 403, 'You can not delete a redflag you do not own'
 
@@ -80,7 +85,7 @@ class RedflagView(viewsets.ModelViewSet):
             response['status'], response['error'] = 404, 'Redflag record could not be found'
 
         return Response(data=response, status=response['status'])
-        
+
     def user_name(self, uid):
         user = User.objects.filter(id=uid)[0]
         return user.username
@@ -99,7 +104,7 @@ class RedflagView(viewsets.ModelViewSet):
             dictionary = dict(redflag)
             dictionary['createdBy'] = self.user_name(dictionary['createdBy'])
             data.append(dictionary)
-            
+
         return JsonResponse({"status": 200,
                              "data": data},
                             status=200)


### PR DESCRIPTION
### What does this PR do?
Fixes deletion of red-flag record that is `under investigation` or has been processed.

### How should you manually test this?

- [x] **Clone the repository**

        $ git clone https://github.com/ann-mukundi/ireporter.git


- [x] **Switch to testing branch**

       $ git checkout bg-fix-delete-redflag-164691118 

- [x] **Switch to the ireporter directory**

       $ cd ireporter/

 

- [x] **Create and activate the virtual environment**

      $  virtualenv -p python .venv


      $ source .venv/bin/activate


- [x] **Install project dependencies**

       $ pip install -r api/requirements.txt


- [x] **Run the database migrations**

       $ python api/manage.py migrate


### Running the application

      $ python api/manage.py runserver


- [x] **Signup and activate user**

           POST <your-localhost>/api/auth/signup/

           POST <your-localhost>/api/auth/activate/

- [x] **Login user**

       POST <your-localhost>/api/auth/login/ 


       Use the token provided after login for Authorization and the endpoint
  
- [x] **Create a redflag record**

     

      POST <your-localhost>/api/redflags/ 

      Use the redflag ID provided in the response for use on redlfag endpoints

- [x] **Update redflag record status (as an Admin user)**

     

      PATCH <your-localhost>/api/redflags/int:redflag-id/status


- [x] **Delete the redflag record**


       DELETE <your-localhost>/api/redflags/int:redflag-id/ 


### Testing

      $ python api/manage.py test


### Prerequisites

Python, Git,  Virtualenv


### What are the relevant PT stories?

[#164691118](https://www.pivotaltracker.com/story/show/164691118)


### Screenshots


![Screenshot from 2019-03-18 13-14-59](https://user-images.githubusercontent.com/33033576/54523176-ea2cf580-497f-11e9-84f7-b8239ccc6a63.png)








