### PR TITLE
#164653611 Update an intervention record

### DIFF
--- a/api/interventions/serializers.py
+++ b/api/interventions/serializers.py
@@ -27,6 +27,8 @@ class InterventionSerializer(serializers.ModelSerializer):
             'comment',
             'createdOn')
 
+        read_only_fields = ['status',]
+
     def create(self, validated_data):
         intervention = TABLE.objects.create(**validated_data)
         return intervention


### PR DESCRIPTION
### What does this PR do?
Adds the Update in the CRUD for an intervention record

### How should you manually test this?

- [x] **Clone the repository**

        $ git clone https://github.com/ann-mukundi/ireporter.git


- [x] **Switch to testing branch**

       $ ft-edit-update-intervention-164653611 

- [x] **Switch to the ireporter directory**

       $ cd ireporter/

 

- [x] **Create and activate the virtual environment**

      $  virtualenv -p python .venv


      $ source .venv/bin/activate


- [x] **Install project dependencies**

       $ pip install -r api/requirements.txt


- [x] **Run the database migrations**

       $ python api/manage.py migrate


### Running the application

      $ python api/manage.py runserver


- [x] **Signup and activate user**

           POST <your-localhost>/api/auth/signup/

           POST <your-localhost>/api/auth/activate/

- [x] **Login user**

       POST <your-localhost>/api/auth/login/ 


       Use the token provided after login for Authorization and the endpoint
  
- [x] **Create an intervention record**

     

      POST <your-localhost>/api/interventions/ 

      Use the redflag ID provided in the response for use on redlfag endpoints

- [x] **Update an intervention record**

     

      PUT <your-localhost>/api/interventions/int:intervention-id/




### Testing

      $ python api/manage.py test


### Prerequisites

Python, Git,  Virtualenv


### What are the relevant PT stories?

[#164653611](https://www.pivotaltracker.com/story/show/164653611)

### Screenshots
**Successfully update a record**
![Screenshot from 2019-03-18 22-31-21](https://user-images.githubusercontent.com/45317755/54560377-4a00bc00-49d3-11e9-9a50-c3e2c8c888ac.png)

**Record update when not the owner**
![Screenshot from 2019-03-18 22-28-59](https://user-images.githubusercontent.com/45317755/54560444-6bfa3e80-49d3-11e9-9020-9d8b3f0a7fda.png)

**Record update if status is not `draft`**
![Screenshot from 2019-03-18 22-27-22](https://user-images.githubusercontent.com/45317755/54560491-846a5900-49d3-11e9-9122-5cf2a82b308d.png)

