### PR TITLE
#164648324 A user should be able to delete an intervention record

### DIFF
--- a/api/interventions/views.py
+++ b/api/interventions/views.py
@@ -172,3 +172,38 @@ class InterventionsView(viewsets.ModelViewSet):
                     pk), 404)
 
         return Response(data=response, status=response['status'])
+
+    def destroy(self, request, **kwargs):
+        """
+        This methods tries to delete an intevention
+        when the user owns it, also, return error message
+        when status is changed or user doesn't own it
+        """
+
+        user_id, response = request.user.id, {}
+
+        try:
+            instance = self.get_object()
+
+            if int(instance.createdBy) != user_id:
+
+                response['status'], response['error'] = 403, \
+                    'You can not delete an intervention record you do not own'
+
+            elif str.lower(instance.status) != str.lower('draft'):
+                response['status'], response['error'] = 403, \
+                    'You can not delete this intervention, it is already '\
+                    + instance.status
+
+            else:
+                self.perform_destroy(instance)
+
+                response['status'], response['message'] = 200, \
+                    'Intervention record successfully deleted'
+
+        except Http404:
+
+            response['status'], response['error'] = 404, \
+                'Intervention record could not be found'
+
+        return Response(data=response, status=response['status'])


### PR DESCRIPTION
### What does this PR do?
Adds an endpoint that deletes intervention record

### Description of the task to be completed?
- Write tests for deleting intervention record 
- Build an endpoint to delete intervention records

### How should you manually test this?

- [x] **Clone the repository**

        $ git clone https://github.com/jkamz/ireporter.git


- [x] **Switch to testing branch**

       $ git checkout ft-delete-intervention-164648324

- [x] **Switch to the ireporter directory**

       $ cd ireporter/

 

- [x] **Create and activate the virtual environment**

      $  virtualenv -p python .venv


      $ source .venv/bin/activate


- [x] **Install project dependencies**

       $ pip install -r api/requirements.txt


- [x] **Run the database migrations**

       $ python api/manage.py migrate


### Running the application

      $ python api/manage.py runserver


- [x] **Signup and activate user**

           POST <your-localhost>/api/auth/signup/

           POST <your-localhost>/api/auth/activate/

- [x] **Login user**

       POST <your-localhost>/api/auth/login/ 


       Use the token provided after login for Authorization and the endpoint
  
- [x] **Create a intervention record**

     

      POST <your-localhost>/api/interventions/ 


- [x] **Delete Intervention record**


       DELETE <your-localhost>/api/interventions/intervention-id/ 

### Testing

      $ python api/manage.py test


### Prerequisites

Python, Git,  Virtualenv


### What are the relevant PT stories?
[#164648324](https://www.pivotaltracker.com/story/show/164648324)



### Screenshots
**Success**
![Screenshot from 2019-03-19 12-03-21](https://user-images.githubusercontent.com/19903559/54594130-1492b780-4a41-11e9-889f-42b149de3a8e.png)

**Non Existent Record**
![Screenshot from 2019-03-19 12-03-27](https://user-images.githubusercontent.com/19903559/54594100-06449b80-4a41-11e9-89f1-a776d5e59622.png)

**Validation**
![Screenshot from 2019-03-19 12-02-47](https://user-images.githubusercontent.com/19903559/54594154-21afa680-4a41-11e9-9d3f-679895f9829c.png)
