### PR TITLE
#164689280 Admin user update red-flag status

### DIFF
--- a/api/incidents/models.py
+++ b/api/incidents/models.py
@@ -10,7 +10,7 @@ class RedflagModel(models.Model):
     incident_type = 'red-flag'
     title = models.CharField(max_length=128)
     location = models.CharField(max_length=150)
-    status = models.CharField(max_length=30, default="draft")
+    status = models.CharField(max_length=30, default='draft')
     Image = models.URLField(blank=True, null=True)
     Video = models.URLField(blank=True, null=True)
     comment = models.TextField(blank=False, null=False)
@@ -21,3 +21,4 @@ class RedflagModel(models.Model):
 
     class Meta:
         ordering = ["-createdOn"]
+

--- a/api/incidents/serializers.py
+++ b/api/incidents/serializers.py
@@ -24,6 +24,26 @@ class IncidentSerializer(serializers.ModelSerializer):
             'comment',
             'createdOn')
 
+        read_only_fields = ['status',]
+
     def create(self, validated_data):
         incident = TABLE.objects.create(**validated_data)
         return incident
+
+
+class AdminRedflagSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TABLE
+        fields = (
+            'id',
+            'url',
+            'createdBy',
+            'title',
+            'incident_type',
+            'location',
+            'status',
+            'Image',
+            'Video',
+            'comment',
+            'createdOn')
+


### PR DESCRIPTION
### What does this PR do?
Adds an endpoint that allows the admin to update the status of a red-flag record

### Description of the task to be completed?
- Build out endpoint responsible for updating the status of a red-flag record

### How should you manually test this?

- [x] **Clone the repository**

        $ git clone https://github.com/ann-mukundi/ireporter.git


- [x] **Switch to testing branch**

       $ git checkout ft-redflag-status-update-164689280

- [x] **Switch to the ireporter directory**

       $ cd ireporter/

 

- [x] **Create and activate the virtual environment**

      $  virtualenv -p python .venv


      $ source .venv/bin/activate


- [x] **Install project dependencies**

       $ pip install -r api/requirements.txt


- [x] **Run the database migrations**

       $ python api/manage.py migrate

- [x] **Create a superuser**

      $ python api/manage.py createsuperuser

### Running the application

      $ python api/manage.py runserver



- [x] **Login user**

       POST <your-localhost>/api/auth/login/ 


       Use the token provided after login for Authorization and the endpoint
  
- [x] **Create an intervention record**

     

      POST <your-localhost>/api/redflags/ 


- [x] **Update intervention status**


       PATCH <your-localhost>/api/redflags/int:redflag-id/status/

### Testing

      $ python api/manage.py test


### Prerequisites

Python, Git,  Virtualenv


### What are the relevant PT stories?

[#16468928](https://www.pivotaltracker.com/story/show/164689280)


### Screenshots
**Success**
![Screenshot from 2019-03-19 22-51-50](https://user-images.githubusercontent.com/45317755/54637420-a9290400-4a99-11e9-91d8-da3c1607bef1.png)




**Non Existent Record**
![Screenshot from 2019-03-19 22-45-43](https://user-images.githubusercontent.com/45317755/54637016-c0b3bd00-4a98-11e9-8da5-25ebcc44eb1c.png)



**Validation**
*Non Admin user*
![Screenshot from 2019-03-19 22-32-50](https://user-images.githubusercontent.com/45317755/54637038-cd381580-4a98-11e9-91fa-35f3583cf1e0.png)

*Incorrect Details*
![Screenshot from 2019-03-19 22-54-10](https://user-images.githubusercontent.com/45317755/54637600-0c1a9b00-4a9a-11e9-9869-42a577190343.png)



**No data provided**
![Screenshot from 2019-03-19 22-32-25](https://user-images.githubusercontent.com/45317755/54637094-eccf3e00-4a98-11e9-9158-faf8818d288f.png)

